### PR TITLE
eyeD3.js: genre field should be of type string

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -23,7 +23,8 @@ var async = require('async');
  *      encoding: {
  *          from: "UTF-8",
  *          to: "ISO-8859-1"
- *      }
+ *      },
+ *      id3v23: true // Default false (ID3 v2.4)
  *  }
  * @throws {ReferenceError} Errors while validate options
  */
@@ -55,7 +56,8 @@ Writer.prototype.setOptions = function(options)
         encoding: {
             from: 'UTF-8',
             to: 'UTF-8'
-        }
+        },
+        id3v23: false
     };
 
     this.options = extend(true, {}, defaultOptions, options || {});

--- a/lib/writer/abstract.js
+++ b/lib/writer/abstract.js
@@ -21,7 +21,8 @@ var Writer = function(options)
         transcode: function(str) {
             return str;
         },
-        encoding: 'ISO-8859-1'
+        encoding: 'ISO-8859-1',
+        id3v23: false
     };
 };
 

--- a/lib/writer/eyeD3.js
+++ b/lib/writer/eyeD3.js
@@ -155,6 +155,10 @@ Writer.prototype.write = function(file, version, meta, callback)
             break;
     }
 
+    if (this.options.id3v23 === true) {
+        args.push('--to-v2.3');
+    }
+
     var self = this;
 
     Object.keys(meta.information).forEach(function(key) {

--- a/lib/writer/eyeD3.js
+++ b/lib/writer/eyeD3.js
@@ -182,7 +182,7 @@ Writer.prototype.write = function(file, version, meta, callback)
                 args.push('-A "' + value + '"');
                 break;
             case 'genre':
-                args.push('-G ' + value);
+                args.push('-G "' + value + '"');
                 break;
             case 'year':
                 args.push('-Y ' + value);


### PR DESCRIPTION
Genre field for eyeD3: `All is possible: std ID3 genre names, ids and any other`
If you set genre field to a string value, eyeD3 fails with the following message:

```
Error: Command failed: /bin/sh: 1: B: not found
Usage
=====
eyeD3 [OPTS] file [file...]
eyeD3: error: File/directory argument(s) required
```