### PR TITLE
[Writer][eyeD3] Genre should be a string

### DIFF
--- a/lib/writer/eyeD3.js
+++ b/lib/writer/eyeD3.js
@@ -182,7 +182,7 @@ Writer.prototype.write = function(file, version, meta, callback)
                 args.push('-A "' + value + '"');
                 break;
             case 'genre':
-                args.push('-G ' + value);
+                args.push('-G "' + value + '"');
                 break;
             case 'year':
                 args.push('-Y ' + value);


### PR DESCRIPTION
Genre field for eyeD3: `All is possible: std ID3 genre names, ids and any other`
If you set genre field to a string value, eyeD3 fails with the following message:

```
Error: Command failed: /bin/sh: 1: B: not found
Usage
=====
eyeD3 [OPTS] file [file...]
eyeD3: error: File/directory argument(s) required
```