### PR TITLE
[Writer][eyeD3] Added support for ID3v2.3 through the use of --to-v2.3 option

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -23,7 +23,8 @@ var async = require('async');
  *      encoding: {
  *          from: "UTF-8",
  *          to: "ISO-8859-1"
- *      }
+ *      },
+ *      id3v23: true // Default false (ID3 v2.4)
  *  }
  * @throws {ReferenceError} Errors while validate options
  */
@@ -55,7 +56,8 @@ Writer.prototype.setOptions = function(options)
         encoding: {
             from: 'UTF-8',
             to: 'UTF-8'
-        }
+        },
+        id3v23: false
     };
 
     this.options = extend(true, {}, defaultOptions, options || {});

--- a/lib/writer/abstract.js
+++ b/lib/writer/abstract.js
@@ -21,7 +21,8 @@ var Writer = function(options)
         transcode: function(str) {
             return str;
         },
-        encoding: 'ISO-8859-1'
+        encoding: 'ISO-8859-1',
+        id3v23: false
     };
 };
 

--- a/lib/writer/eyeD3.js
+++ b/lib/writer/eyeD3.js
@@ -155,6 +155,10 @@ Writer.prototype.write = function(file, version, meta, callback)
             break;
     }
 
+    if (this.options.id3v23 === true) {
+        args.push('--to-v2.3');
+    }
+
     var self = this;
 
     Object.keys(meta.information).forEach(function(key) {


### PR DESCRIPTION
Windows Media Player will not recognize ID3 v2.4 tags. Most of the media players that support ID3 v2.4 also support ID3 v2.3.

`--to-v2.3` flag is supported by eyeD3 v0.7.+ . However, I was unable to install eyeD3 v0.6 or find the docs for it. Though [this repo](https://github.com/formorer/pkg-eyed3) seems to have eyeD3 python package v0.6 that supports `--to-v2.3` flag.
