### PR TITLE
Escaped double quotes in file paths for eyeD3 writer

### DIFF
--- a/lib/writer/eyeD3.js
+++ b/lib/writer/eyeD3.js
@@ -110,7 +110,7 @@ Writer.prototype.clear = function(file, version, callback)
         commandTemplate,
         this.methods.clear,
         args.join(' '),
-        file.getPath()
+        file.getPath().replace(/"/g, '\\"')
     );
 
     this.exec(command, callback)
@@ -168,7 +168,7 @@ Writer.prototype.write = function(file, version, meta, callback)
 
         // Transcode strings
         if ('string' === typeof value) {
-            value = self.options.transcode(value);
+            value = self.options.transcode(value.replace(/"/g, ''));
         }
 
         switch (key) {
@@ -225,7 +225,7 @@ Writer.prototype.write = function(file, version, meta, callback)
 
             args.push(util.format(
                 arg,
-                image.getFile().getPath(),
+                image.getFile().getPath().replace(/"/g, '\\"'),
                 image.getType(),
                 (image.getDescription())
                     ? (':"' + image.getDescription() + '"')
@@ -238,11 +238,10 @@ Writer.prototype.write = function(file, version, meta, callback)
         commandTemplate,
         this.methods.write,
         args.join(' '),
-        file.getPath()
+        file.getPath().replace(/"/g, '\\"')
     );
 
     this.exec(command, callback)
 };
 
 module.exports = Writer;
-


### PR DESCRIPTION
eyeD3 writer failed for file paths which contained double quotes