### PR TITLE
Fix eyeD3 version check

### DIFF
--- a/lib/writer/eyeD3.js
+++ b/lib/writer/eyeD3.js
@@ -56,7 +56,7 @@ Writer.prototype.configure = function(callback)
         // We need to skip error handling - eyeD3 exit with
         // code 1 on --version requests - whyever
         // So stderr contains the normal stdout
-        stdout = stderr || '';
+        stdout = stderr || stdout || '';
 
         if (~stdout.indexOf('0.6.')) {
             self.version = '0.6';


### PR DESCRIPTION
I do not know which version of eyeD3 exists with code 1, but my version (0.6.18) exits with 0. This pull request fixes version check for the case when eyeD3 exits with 0.
